### PR TITLE
Bump runtime to 3.36

### DIFF
--- a/org.freedesktop.Bustle.yaml
+++ b/org.freedesktop.Bustle.yaml
@@ -1,7 +1,7 @@
 # vim: sts=2 sw=2 et
 app-id: org.freedesktop.Bustle
 runtime: org.gnome.Platform
-runtime-version: "3.28"
+runtime-version: "3.36"
 sdk: org.gnome.Sdk
 # Use writable-sdk to install Haskell Platform to usr rather than app:
 # it's only needed to build Bustle, not to run it. All Haskell libraries


### PR DESCRIPTION
Bustle is one of two packages on my machine that depend on 3.28 still. :)